### PR TITLE
Fix compute PlaceHolder position

### DIFF
--- a/AlphaChiTech.Virtualization/PaginationManager.cs
+++ b/AlphaChiTech.Virtualization/PaginationManager.cs
@@ -1078,7 +1078,7 @@ namespace AlphaChiTech.Virtualization
                             //Debug.WriteLine("Filling with placeholders, pagesize=" + pageSize);
                             for (int loop = 0; loop < pageSize; loop++)
                             {
-                                newPage.Append(this.ProviderAsync.GetPlaceHolder(index+loop, newPage.Page, loop), null, this.ExpiryComparer);
+                                newPage.Append(this.ProviderAsync.GetPlaceHolder(newPage.Page * pageSize + loop, newPage.Page, loop), null, this.ExpiryComparer);
                             }
 
                             ret = newPage;

--- a/AlphaChiTech.Virtualization/SourcePage.cs
+++ b/AlphaChiTech.Virtualization/SourcePage.cs
@@ -184,7 +184,7 @@ namespace AlphaChiTech.Virtualization
         {
             if (IsSafeToUpdate(comparer, updatedAt))
             {
-                _Items[offset] = newValue;
+                if (_Items.Count > offset) _Items[offset] = newValue;
             }
         }
 


### PR DESCRIPTION
In the procedure GetPlaceHolder need to pass a parameter the index of the first element of the page, but passes the Index of the first visible list item.